### PR TITLE
Use robot_name in open_manipulator_gazebo.launch

### DIFF
--- a/open_manipulator_gazebo/config/open_manipulator_controller.yaml
+++ b/open_manipulator_gazebo/config/open_manipulator_controller.yaml
@@ -1,30 +1,29 @@
-open_manipulator:
-  # Publish all joint states -----------------------------------
-  joint_state_controller:
-    type: joint_state_controller/JointStateController
-    publish_rate: 1000
+# Publish all joint states -----------------------------------
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 1000
 
-  # Position Controllers ---------------------------------------
-  joint1_position:
-    type: position_controllers/JointPositionController
-    joint: joint1
+# Position Controllers ---------------------------------------
+joint1_position:
+  type: position_controllers/JointPositionController
+  joint: joint1
 
-  joint2_position:
-    type: position_controllers/JointPositionController
-    joint: joint2
+joint2_position:
+  type: position_controllers/JointPositionController
+  joint: joint2
 
-  joint3_position:
-    type: position_controllers/JointPositionController
-    joint: joint3
+joint3_position:
+  type: position_controllers/JointPositionController
+  joint: joint3
 
-  joint4_position:
-    type: position_controllers/JointPositionController
-    joint: joint4
+joint4_position:
+  type: position_controllers/JointPositionController
+  joint: joint4
 
-  gripper_position:
-    type: position_controllers/JointPositionController
-    joint: gripper
+gripper_position:
+  type: position_controllers/JointPositionController
+  joint: gripper
 
-  gripper_sub_position:
-    type: position_controllers/JointPositionController
-    joint: gripper_sub
+gripper_sub_position:
+  type: position_controllers/JointPositionController
+  joint: gripper_sub

--- a/open_manipulator_gazebo/launch/open_manipulator_controller.launch
+++ b/open_manipulator_gazebo/launch/open_manipulator_controller.launch
@@ -2,7 +2,8 @@
   <arg name="use_robot_name"         default="open_manipulator"/>
 
   <!-- Load joint controller configurations from YAML file to parameter server -->
-  <rosparam file="$(find open_manipulator_gazebo)/config/open_manipulator_controller.yaml" command="load"/>
+  <rosparam file="$(find open_manipulator_gazebo)/config/open_manipulator_controller.yaml" command="load"
+            ns="$(arg use_robot_name)"/>
 
   <!-- load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"

--- a/open_manipulator_gazebo/launch/open_manipulator_gazebo.launch
+++ b/open_manipulator_gazebo/launch/open_manipulator_gazebo.launch
@@ -1,12 +1,12 @@
 <launch>
   <!-- These are the arguments you can pass this launch file, for example paused:=true -->
+  <arg name="use_robot_name" default="open_manipulator"
+       doc="Must match the robotNamespace tag in the gazebo description file"/>
   <arg name="paused" default="true"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
-
-  <rosparam file="$(find open_manipulator_gazebo)/config/gazebo_controller.yaml" command="load" />
 
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
@@ -27,5 +27,7 @@
      args="-urdf -model open_manipulator -z 0.0 -param robot_description"/>
 
   <!-- ros_control robotis manipulator launch file -->
-  <include file="$(find open_manipulator_gazebo)/launch/open_manipulator_controller.launch"/>
+  <include file="$(find open_manipulator_gazebo)/launch/open_manipulator_controller.launch">
+    <arg name="use_robot_name" value="$(arg use_robot_name)"/>
+  </include>
 </launch>


### PR DESCRIPTION
Allow user to specify `robot_name` from `open_manipulator_gazebo.launch`.

Also, use it as namespace when loading the config file, to support names other than `open_manipulator` (The name must match the gazebo [robotNamespace](https://github.com/ROBOTIS-JAPAN-GIT/open_manipulator/blob/dynamixel_mikata_arm/open_manipulator_description/urdf/open_manipulator.gazebo.xacro#L50), though)