### PR TITLE
Added gazebo ros control parameters

### DIFF
--- a/open_manipulator_gazebo/config/gazebo_controller.yaml
+++ b/open_manipulator_gazebo/config/gazebo_controller.yaml
@@ -1,0 +1,7 @@
+gazebo_ros_control:
+  pid_gains:
+    joint1: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    joint2: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    joint3: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    joint4: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    gripper_sub: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}

--- a/open_manipulator_gazebo/launch/open_manipulator_gazebo.launch
+++ b/open_manipulator_gazebo/launch/open_manipulator_gazebo.launch
@@ -4,6 +4,8 @@
   <arg name="paused" default="true"/>
   <arg name="use_sim_time" default="true"/>
 
+  <rosparam file="$(find open_manipulator_gazebo)/config/gazebo_controller.yaml" command="load"/>
+
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find open_manipulator_gazebo)/worlds/empty.world"/>


### PR DESCRIPTION
Added gazebo ROS control parameters that are loaded via the open_manipulator_gazebo.launch file. Without these, the gripper can't lift anything. <hasPID>/gazebo_ros_control/pid_gains/gripper_sub</hasPID> still needs to be added to the mimic joint in the urdf. Submitted PR for that now.